### PR TITLE
feat: add --disable CLI option

### DIFF
--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -27,6 +27,7 @@ vscode-as-mcp-relay --server-url http://localhost:60100 --listen-port 6011
 
 - `--server-url`: Base URL of the MCP server (default: http://localhost:60100)
 - `--listen-port`: Starting port to listen for incoming JSON-RPC messages (default: 6011)
+- `--disable`: Disable specific tools from being displayed (e.g., `--disable text_editor --disable list_directory`)
 
 ## Custom Protocol
 


### PR DESCRIPTION
Adds a command-line interface option `--disable` to allow users to disable the display of certain tools when launching MCP.